### PR TITLE
Support MySQL 5.7 and use cluster name

### DIFF
--- a/plugins/nagios/README
+++ b/plugins/nagios/README
@@ -50,7 +50,7 @@ Step 2: Configure Nagios Plugin
         use                             generic-service
         host_name                       clustercontrol.mydomain.org
         service_description             Database Cluster
-        check_command                   s9s_cluster_status!<your credentials file>!<cluster name>
+        check_command                   s9s_cluster_status!<your credentials file>!<cluster name>!cluster
         notifications_enabled           1
         }
 
@@ -58,9 +58,84 @@ Step 2: Configure Nagios Plugin
         use                             generic-service
         host_name                       clustercontrol.mydomain.org
         service_description             Alarms
-        check_command                   s9s_cluster_status!<your credentials file>!<cluster name>!<alarm>
+        check_command                   s9s_cluster_status!<your credentials file>!<cluster name>!alarm
         notifications_enabled           1
         }
+	
+===============================
+Step 2: Configure Icinga2 Plugin
+===============================
+
+- Login into Cluster control host and copy the plugin into Icinga2 plugin directory, for example:
+  $ cp s9s-admin/plugin/nagios/s9s_cluster_status /usr/local/icinga2/plugin
+  
+ - Create Icinga2 check command:
+ object CheckCommand "check-clustercontrol-cluster" {
+  import "plugin-check-command"
+
+  command = [ CustomPluginDir + "/s9s_cluster_status" ]
+
+  arguments = {
+    "-c" = "$cmon_login$"
+    "-H" = "$host$"
+    "-n" = "$name$"
+    "-t" = "$type$"
+  }
+ }
+ object CheckCommand "check-clustercontrol-cluster-alarm" {
+  import "plugin-check-command"
+
+  command = [ CustomPluginDir + "/s9s_cluster_status" ]
+
+  arguments = {
+    "-c" = "$cmon_login$"
+    "-H" = "$host$"
+    "-n" = "$name$"
+    "-t" = "$type$"
+  }
+ }
+ 
+ - Create Icinga2 service definitions:
+ 
+ apply Service for (cluster => config in host.vars.config.clustercontrol) {
+  import "generic-service"
+
+  vars += config
+  if (host.vars.config.cmon.credentials.file) {
+    vars.cmon_login = host.vars.config.cmon.credentials.file
+  } else {
+    vars.cmon_login = "/etc/icinga2/localconf.d/icinga_my.cnf"
+  }
+  vars.type = "cluster"
+
+  enable_perfdata = 0
+  command_endpoint = host.vars.client_endpoint
+  check_command = "check-clustercontrol-cluster"
+  assign where host.vars.service.clustercontrol == "yes"
+ }
+ apply Service "cluster-alarms" {
+  import "generic-service"
+
+  if (host.vars.config.cmon.credentials.file) {
+    vars.cmon_login = host.vars.config.cmon.credentials.file
+  } else {
+    vars.cmon_login = "/etc/icinga2/localconf.d/icinga_my.cnf"
+  }
+  vars.host = "localhost"
+  vars.type = "alarm"
+  
+  enable_perfdata = 0
+  command_endpoint = host.vars.client_endpoint
+  check_command = "check-clustercontrol-cluster-alarm"
+  assign where host.vars.service.clustercontrol == "yes"
+ }
+
+ - Add host variables to host object to monitor cluster with name my_cluster on localhost:
+   
+   vars.config.clustercontrol.cluster_name.host = "localhost"
+   vars.config.clustercontrol.cluster_name.cluster_name = "my_cluster"
+   vars.service.clustercontrol = "yes"
+
 
 =====
 Notes

--- a/plugins/nagios/README
+++ b/plugins/nagios/README
@@ -33,7 +33,7 @@ Step 2: Configure Nagios Plugin
 
   define command{
         command_name    s9s_cluster_status
-        command_line    $USER1$/s9s_cluster_status -H $HOSTADDRESS$ -c $ARG1$ -t $ARG2$
+        command_line    $USER1$/s9s_cluster_status -H $HOSTADDRESS$ -c $ARG1$ -n $ARG2$ -t $ARG3$
   }
 
 
@@ -50,7 +50,7 @@ Step 2: Configure Nagios Plugin
         use                             generic-service
         host_name                       clustercontrol.mydomain.org
         service_description             Database Cluster
-        check_command                   s9s_cluster_status!<your credentials file>
+        check_command                   s9s_cluster_status!<your credentials file>!<cluster name>
         notifications_enabled           1
         }
 
@@ -58,7 +58,7 @@ Step 2: Configure Nagios Plugin
         use                             generic-service
         host_name                       clustercontrol.mydomain.org
         service_description             Alarms
-        check_command                   s9s_cluster_status!<your credentials file>!alarm
+        check_command                   s9s_cluster_status!<your credentials file>!<cluster name>!<alarm>
         notifications_enabled           1
         }
 

--- a/plugins/nagios/README
+++ b/plugins/nagios/README
@@ -82,18 +82,6 @@ Step 2: Configure Icinga2 Plugin
     "-t" = "$type$"
   }
  }
- object CheckCommand "check-clustercontrol-cluster-alarm" {
-  import "plugin-check-command"
-
-  command = [ CustomPluginDir + "/s9s_cluster_status" ]
-
-  arguments = {
-    "-c" = "$cmon_login$"
-    "-H" = "$host$"
-    "-n" = "$name$"
-    "-t" = "$type$"
-  }
- }
  
  - Create Icinga2 service definitions:
  
@@ -126,7 +114,7 @@ Step 2: Configure Icinga2 Plugin
   
   enable_perfdata = 0
   command_endpoint = host.vars.client_endpoint
-  check_command = "check-clustercontrol-cluster-alarm"
+  check_command = "check-clustercontrol-cluster"
   assign where host.vars.service.clustercontrol == "yes"
  }
 

--- a/plugins/nagios/README
+++ b/plugins/nagios/README
@@ -16,7 +16,11 @@ Step 1: Grant permission for cmon DB user
 - Login into ClusterControl host:
   mysql> GRANT SELECT ON cmon.* TO 'cmon'@'<nagios_host_ip>' IDENTIFIED BY '<cmon_password>';
   mysql> FLUSH PRIVILEGES;
-
+ 
+- Create credentials file:
+  [client]
+  user=<cmon_user>
+  password=<cmon_password>
 
 ===============================
 Step 2: Configure Nagios Plugin
@@ -29,7 +33,7 @@ Step 2: Configure Nagios Plugin
 
   define command{
         command_name    s9s_cluster_status
-        command_line    $USER1$/s9s_cluster_status -H $HOSTADDRESS$ -p $ARG1$ -t $ARG2$
+        command_line    $USER1$/s9s_cluster_status -H $HOSTADDRESS$ -c $ARG1$ -t $ARG2$
   }
 
 
@@ -46,7 +50,7 @@ Step 2: Configure Nagios Plugin
         use                             generic-service
         host_name                       clustercontrol.mydomain.org
         service_description             Database Cluster
-        check_command                   s9s_cluster_status!yourcmonpassword
+        check_command                   s9s_cluster_status!<your credentials file>
         notifications_enabled           1
         }
 
@@ -54,7 +58,7 @@ Step 2: Configure Nagios Plugin
         use                             generic-service
         host_name                       clustercontrol.mydomain.org
         service_description             Alarms
-        check_command                   s9s_cluster_status!yourcmonpassword!alarm
+        check_command                   s9s_cluster_status!<your credentials file>!alarm
         notifications_enabled           1
         }
 
@@ -63,10 +67,10 @@ Notes
 ===== 
 
 - If you used non-default MySQL port, add another option and argument under command_line directive:
-	command_line	$USER1$/s9s_cluster_status -H $HOSTADDRESS$ -p $ARG1$ -P $ARG2$
+	command_line	$USER1$/s9s_cluster_status -H $HOSTADDRESS$ -c $ARG1$ -P $ARG2$
 
 - Then, under check_command directive, add the port argument:
-	check_command	s9s_cluster_status!password!3307   ## Format: <command name>!<cmon password>!<MySQL port>
+	check_command	s9s_cluster_status!credential file!3307   ## Format: <command name>!<cmon crendential file>!<MySQL port>
 
 - If you create an individual object config file under "objects" directory, do not forget to call the config file inside nagios.cfg, for example:
 	cfg_file=/usr/local/nagios/etc/objects/clustercontrol.cfg

--- a/plugins/nagios/s9s_cluster_status
+++ b/plugins/nagios/s9s_cluster_status
@@ -3,17 +3,18 @@
 # More information is in the COPYING file in the top directory of this package.
 # Copyright (C) 2011 Severalnines
 
-VERSION=0.4
+VERSION=0.5
 
-TEMP=`getopt -o H:,p:,t:,P:,h,v --long host:,password:,type:,port:,help,version -n 's9s_cluster_status' -- "$@"`
+TEMP=`getopt -o H:,c:,t:,P:,i:,h,v --long host:,config:,type:,port:,id:,help,version -n 's9s_cluster_status' -- "$@"`
 eval set -- "$TEMP"
 
 while true ; do
   case "$1" in
     -H|--host) cmon_db_host="$2" ; shift 2 ;;
-    -p|--password) cmon_db_password="$2" ; shift 2 ;;
+    -c|--config) cmon_db_config="$2" ; shift 2 ;;
     -t|--type) query_type="$2" ; shift 2 ;;
     -P|--port) cmon_db_port="$2" ; shift 2 ;;
+    -i|--id) cmon_db_cluster_id="$2" ; shift 2 ;;
     -h|--help) help="1" ; shift ;;
     -v|--version) version="1" ; shift ;;
     --) shift ; break ;;
@@ -22,169 +23,166 @@ while true ; do
 done
 
 printVersion(){
-        echo "Plugin  : Check Database Cluster Status (Nagios)"
-        echo "Version : $VERSION"
-        echo "Author  : Severalnines"
-        echo ""
+  echo "Plugin  : Check Database Cluster Status (Nagios)"
+  echo "Version : $VERSION"
+  echo "Author  : Severalnines"
+  echo ""
 }
 
 helpMenu(){
-        echo "Usage   : `basename $0` -H [host] -p [cmon_password] [options]"
-        echo ""
-        echo "-H, --host      : ClusterControl/cmon IP address"
-        echo "-p, --password  : DB password for user cmon"
-        echo "-t, --type      : Query type [cluster|alarm] (default: cluster)"
-        echo "-P, --port      : MySQL port for the host (default: 3306)"
-        echo "-h, --help      : Print help"
-        echo ""
-        echo "Example: `basename $0` -H 127.0.0.1 -p 'password' -t cluster"
-        echo ""
+  echo "Usage   : `basename $0` -H [host] -c [cmon_mysql_config] [options]"
+  echo ""
+  echo "-H, --host      : ClusterControl/cmon IP address"
+  echo "-c, --config    : MySQL credential file for user cmon"
+  echo "-t, --type      : Query type [cluster|alarm] (default: cluster)"
+  echo "-P, --port      : MySQL port for the host (default: 3306)"
+  echo "-i, --id        : Cluster ID to check"
+  echo "-h, --help      : Print help"
+  echo ""
+  echo "Example: `basename $0` -H 127.0.0.1 -c config -t cluster -i 1"
+  echo ""
 }
 
 if [ ! -z "$version" ]; then
-	printVersion
-	exit 0
+  printVersion
+  exit 0
 fi
 
 # Help menu
 if [ ! -z "$help" ]; then
-	printVersion
-	helpMenu
-	exit 0
+  printVersion
+  helpMenu
+  exit 0
 fi
 
 # Set default value
 [ -z $cmon_db_port ] && cmon_db_port=3306
 [ -z $query_type ] && query_type="cluster"
+[ -z $cmon_db_cluster_id ] && cmon_db_cluster_id=1
 
-if [ -z "$cmon_db_host" ] || [ -z "$cmon_db_password" ]; then
-	echo ""
+if [ -z "$cmon_db_host" ] || [ -z "$cmon_db_config" ]; then
+  echo ""
         helpMenu
-	exit 1
+  exit 1
 fi
 
 check_mysqlbin(){
-	mysqlbin=`which mysql`
-	if [ -z "$mysqlbin" ]; then
-		echo "MySQL client not found. Kindly add the MySQL client into PATH or install MySQL client package"
-		echo "or change and specify the full path to the mysql client (in the beginning of this file): "
-		echo "mysqlbin=\`which mysql\`"
-		echo "to:"
-		echo "mysqlbin=/path/to/mysql"
-	        exit 1
-	fi
+  mysqlbin=`which mysql`
+  if [ -z "$mysqlbin" ]; then
+    echo "MySQL client not found. Kindly add the MySQL client into PATH or install MySQL client package"
+    echo "or change and specify the full path to the mysql client (in the beginning of this file): "
+    echo "mysqlbin=\`which mysql\`"
+    echo "to:"
+    echo "mysqlbin=/path/to/mysql"
+    exit 1
+  fi
 
-	test_query="SELECT * from cmon.hosts;"
-	$mysqlbin -h$cmon_db_host -ucmon -p$cmon_db_password -P$cmon_db_port -A -Bse "$test_query" > /dev/null
-	retval=$?
-	if [ $retval != 0 ]; then
-		echo "Failed to query cmon database. Please check MySQL cmon user privileges on $cmon_db_host." && exit 1
-	fi
+  test_query="SELECT * from cmon.hosts;"
+  $mysqlbin --defaults-file=$cmon_db_config -h$cmon_db_host -P$cmon_db_port -A -Bse "$test_query" > /dev/null
+  retval=$?
+  if [ $retval != 0 ]; then
+    echo "Failed to query cmon database. Please check MySQL cmon user privileges on $cmon_db_host." && exit 1
+  fi
 
-	return 0
+  return 0
 }
 
 if [ $query_type == "cluster" ]; then
+  # SQL query
+  query="SELECT status FROM cmon.cluster_state WHERE id=$cmon_db_cluster_id;"
 
-	# SQL query
-	query='SELECT status FROM cmon.cluster_state WHERE id=1;'
-	
-	check_mysqlbin
-	
-	if [ $? -eq 0 ]; then
-		execute_query=`$mysqlbin -h$cmon_db_host -ucmon -p$cmon_db_password -P$cmon_db_port -A -Bse "$query"`
-		if [ ! "$execute_query" ]; then
-			echo "Failed to query cmon database. The following query failed : $query"
-			echo "Unknown: Cluster status is UNKNOWN"
-			stateid=3
-			exit $stateid
-		else
-			clustate=$execute_query
-		fi
-	fi
+  check_mysqlbin
+  if [ $? -eq 0 ]; then
+    execute_query=`$mysqlbin --defaults-file=$cmon_db_config -h$cmon_db_host -P$cmon_db_port -A -Bse "$query"`
+    if [ ! "$execute_query" ]; then
+      echo "Failed to query cmon database. The following query failed : $query"
+      echo "Unknown: Cluster status is UNKNOWN"
+      stateid=3
+      exit $stateid
+    else
+      clustate=$execute_query
+    fi
+  fi
 
-	if [ "$clustate" == "STARTED" ]; then
-		echo "OK: Cluster status is STARTED"
-	        stateid=0
-	elif  [ "$clustate" == "CRITICAL" ] || [ "$clustate" == "FAILURE" ] || [ "$clustate" == "STOPPED" ] || [ "$clustate" == "SHUTTING_DOWN" ]; then
-        	echo "Critical: Cluster status is $clustate"
-	        stateid=2
-	else
-	        echo "Warning: Cluster status is $clustate"
-	        stateid=1
-	fi
+  if [ "$clustate" == "STARTED" ]; then
+    echo "OK: Cluster status is STARTED"
+    stateid=0
+  elif  [ "$clustate" == "CRITICAL" ] || [ "$clustate" == "FAILURE" ] || [ "$clustate" == "STOPPED" ] || [ "$clustate" == "SHUTTING_DOWN" ]; then
+    echo "Critical: Cluster status is $clustate"
+    stateid=2
+  else
+    echo "Warning: Cluster status is $clustate"
+    stateid=1
+  fi
 
-	exit $stateid
+  exit $stateid
 
 elif [ $query_type == "alarm" ]; then
-
-	# SQL query
-	query='SELECT severity,alarm_name, message,cmon.simple_alarm.report_ts \
+  # SQL query
+query='SELECT severity,alarm_name, message,cmon.simple_alarm.report_ts \
 FROM cmon.simple_alarm \
 LEFT JOIN cmon.hosts \
 ON cmon.simple_alarm.hostid=cmon.hosts.id \
 WHERE ignored=0;'
 
-	check_mysqlbin
+  check_mysqlbin
+  if [ $? -eq 0 ]; then
+    # Comma delimited on query result
+    execute_query=`$mysqlbin --defaults-file=$cmon_db_config -h$cmon_db_host -P$cmon_db_port -A -Bse "$query" | sed "s/'/\'/;s/\t/,/g;s/^//;s/$//;s/\n//g"`
+  if [ "$execute_query" ]; then
+    # Count severity's number
+    INPUT=/tmp/query_result
+    OUTPUT=/tmp/output
+    [ -f $INPUT ] && rm -Rf $INPUT
+    [ -f $OUTPUT ] && rm -Rf $OUTPUT
+    echo "$execute_query" > $INPUT
 
-	if [ $? -eq 0 ]; then
-		# Comma delimited on query result
-		execute_query=`$mysqlbin -h$cmon_db_host -ucmon -p$cmon_db_password -P$cmon_db_port -A -Bse "$query" | sed "s/'/\'/;s/\t/,/g;s/^//;s/$//;s/\n//g"`
-		if [ "$execute_query" ]; then
-			# Count severity's number
-			INPUT=/tmp/query_result
-			OUTPUT=/tmp/output
-			[ -f $INPUT ] && rm -Rf $INPUT
-			[ -f $OUTPUT ] && rm -Rf $OUTPUT
-			echo "$execute_query" > $INPUT
+    OLDIFS=$IFS
+    IFS=,
+    critical=0; warning=0;
+    while read severity hostname alarm description timestamp
+    do
+      if [ ! -z $severity ]; then
+        if [ $severity == "CRITICAL" ]; then
+          critical=$(($critical+1))
+        fi
+        if [ $severity == "WARNING" ]; then
+          warning=$(($warning+1))
+        fi
+      fi
+      # Turn output to array
+      full_status=($severity $hostname $alarm)
+      echo -n "${full_status[*]} | " >> $OUTPUT
+    done < $INPUT
+    IFS=$OLDIFS
 
-			
-			OLDIFS=$IFS
-			IFS=,
-			critical=0; warning=0;
-			while read severity hostname alarm description timestamp
-			do
-				if [ ! -z $severity ]; then
-					if [ $severity == "CRITICAL" ]; then
-						critical=$(($critical+1))
-					fi
-					if [ $severity == "WARNING" ]; then
-						warning=$(($warning+1))
-					fi
-				fi
-			# Turn output to array
-			full_status=($severity $hostname $alarm)
-			echo -n "${full_status[*]} | " >> $OUTPUT
-			done < $INPUT
-			IFS=$OLDIFS
-
-			if [ $critical != 0 ] && [ $warning != 0 ]; then
-				echo "CRITICAL: $critical alarm(s), WARNING: $warning alarm(s) | $(cat $OUTPUT)"
-				stateid=2
-                        elif [ $critical != 0 ]; then
-                                echo "CRITICAL: $critical alarm(s) | $(cat $OUTPUT)"
-				stateid=2
-			elif [ $warning != 0 ]; then
-				echo "WARNING: $warning alarm(s) | $(cat $OUTPUT)"
-				stateid=1
-			else
-				echo "OK: No alarms"
-				stateid=0
-			fi
-		else
-                        if [ $retval -eq 0 ]; then
-                                echo "OK: No alarms"
-                                stateid=0
-			else
-                                echo "Failed to query cmon database. The following query failed : $query"
-                                echo "Unknown: Alarm status is UNKNOWN"
-                                stateid=3
-			fi
-		fi
-		exit $stateid
-	fi
+  if [ $critical != 0 ] && [ $warning != 0 ]; then
+    echo "CRITICAL: $critical alarm(s), WARNING: $warning alarm(s) | $(cat $OUTPUT)"
+    stateid=2
+    elif [ $critical != 0 ]; then
+      echo "CRITICAL: $critical alarm(s) | $(cat $OUTPUT)"
+      stateid=2
+    elif [ $warning != 0 ]; then
+      echo "WARNING: $warning alarm(s) | $(cat $OUTPUT)"
+      stateid=1
+    else
+      echo "OK: No alarms"
+      stateid=0
+    fi
+    else
+    if [ $retval -eq 0 ]; then
+      echo "OK: No alarms"
+      stateid=0
+    else
+      echo "Failed to query cmon database. The following query failed : $query"
+      echo "Unknown: Alarm status is UNKNOWN"
+      stateid=3
+    fi
+  fi
+  exit $stateid
+fi
 
 else
-	echo "Unknown query type. Use following query type: [alarm|cluster]"
-	exit 1
+  echo "Unknown query type. Use following query type: [alarm|cluster]"
+  exit 1
 fi

--- a/plugins/nagios/s9s_cluster_status
+++ b/plugins/nagios/s9s_cluster_status
@@ -5,7 +5,7 @@
 
 VERSION=0.5
 
-TEMP=`getopt -o H:,c:,t:,P:,i:,h,v --long host:,config:,type:,port:,id:,help,version -n 's9s_cluster_status' -- "$@"`
+TEMP=`getopt -o H:,c:,t:,P:,n:,h,v --long host:,config:,type:,port:,name:,help,version -n 's9s_cluster_status' -- "$@"`
 eval set -- "$TEMP"
 
 while true ; do
@@ -14,7 +14,7 @@ while true ; do
     -c|--config) cmon_db_config="$2" ; shift 2 ;;
     -t|--type) query_type="$2" ; shift 2 ;;
     -P|--port) cmon_db_port="$2" ; shift 2 ;;
-    -i|--id) cmon_db_cluster_id="$2" ; shift 2 ;;
+    -n|--name) cmon_cluster_name="$2" ; shift 2 ;;
     -h|--help) help="1" ; shift ;;
     -v|--version) version="1" ; shift ;;
     --) shift ; break ;;
@@ -36,10 +36,10 @@ helpMenu(){
   echo "-c, --config    : MySQL credential file for user cmon"
   echo "-t, --type      : Query type [cluster|alarm] (default: cluster)"
   echo "-P, --port      : MySQL port for the host (default: 3306)"
-  echo "-i, --id        : Cluster ID to check"
+  echo "-n, --name      : Cluster name to check"
   echo "-h, --help      : Print help"
   echo ""
-  echo "Example: `basename $0` -H 127.0.0.1 -c config -t cluster -i 1"
+  echo "Example: `basename $0` -H 127.0.0.1 -c config -t cluster -n default"
   echo ""
 }
 
@@ -58,7 +58,7 @@ fi
 # Set default value
 [ -z $cmon_db_port ] && cmon_db_port=3306
 [ -z $query_type ] && query_type="cluster"
-[ -z $cmon_db_cluster_id ] && cmon_db_cluster_id=1
+[ -z $cmon_cluster_name ] && cmon_cluster_name="default"
 
 if [ -z "$cmon_db_host" ] || [ -z "$cmon_db_config" ]; then
   echo ""
@@ -89,7 +89,7 @@ check_mysqlbin(){
 
 if [ $query_type == "cluster" ]; then
   # SQL query
-  query="SELECT status FROM cmon.cluster_state WHERE id=$cmon_db_cluster_id;"
+  query="SELECT status FROM cmon.cluster_state cs LEFT JOIN cmon.cluster c USING (id) WHERE c.name=\"$cmon_cluster_name\";"
 
   check_mysqlbin
   if [ $? -eq 0 ]; then


### PR DESCRIPTION
Credentials on command line generates a warning in mysql >= 5.7. Update s9s_cluster_status to use mysql defaults file for username and password.
Use cluster name instead of cluster id.
Add Icinga2 config example.